### PR TITLE
Fix minor issues + minor improvement

### DIFF
--- a/inc/classes/BxDolCmtsGridAdministration.php
+++ b/inc/classes/BxDolCmtsGridAdministration.php
@@ -20,7 +20,6 @@ class BxDolCmtsGridAdministration extends BxTemplGrid
     
     public function __construct ($aOptions, $oTemplate = false)
     {
-        
         $this->_sFilter1Name = 'filter1';
 
         $aModules = BxDolModuleQuery::getInstance()->getModulesBy(array('type' => 'modules', 'active' => 1));

--- a/inc/classes/BxDolDb.php
+++ b/inc/classes/BxDolDb.php
@@ -230,7 +230,6 @@ class BxDolDb extends BxDolFactory implements iBxDolSingleton
 			);
 
     	$this->error($oException->errorInfo[self::$_sErrorKey]);
-    	return;
     }
 
     /**

--- a/modules/boonex/acl/classes/BxAclDb.php
+++ b/modules/boonex/acl/classes/BxAclDb.php
@@ -13,10 +13,7 @@ class BxAclDb extends BxDolModuleDb
 {
     protected $_oConfig;
 
-    /*
-     * Constructor.
-     */
-    function __construct(&$oConfig)
+    public function __construct(&$oConfig)
     {
         parent::__construct($oConfig);
 

--- a/modules/boonex/acl/classes/BxAclDb.php
+++ b/modules/boonex/acl/classes/BxAclDb.php
@@ -23,7 +23,6 @@ class BxAclDb extends BxDolModuleDb
 	public function getLevels($aParams, $bReturnCount = false)
     {
         $aMethod = array('name' => 'getAll', 'params' => array(0 => 'query'));
-        $sSelectClause = $sJoinClause = $sWhereClause = $sOrderClause = $sLimitClause = "";
 
         $sSelectClause = "
 			`tal`.`ID` AS `id`,
@@ -37,6 +36,8 @@ class BxAclDb extends BxDolModuleDb
 			`tal`.`QuotaNumber` AS `quota_number`,
 			`tal`.`QuotaMaxFileSize` AS `quota_max_file_size`,
 			`tal`.`Order` AS `order`";
+
+        $sWhereClause = '';
 
         if(!isset($aParams['order']) || empty($aParams['order']))
            $sOrderClause = "ORDER BY `tal`.`Order` ASC";
@@ -85,7 +86,6 @@ class BxAclDb extends BxDolModuleDb
 	public function getPrices($aParams, $bReturnCount = false)
     {
         $aMethod = array('name' => 'getAll', 'params' => array(0 => 'query'));
-        $sSelectClause = $sJoinClause = $sWhereClause = $sOrderClause = $sLimitClause = "";
 
         $sSelectClause = "
 			`tap`.`id` AS `id`,
@@ -97,8 +97,10 @@ class BxAclDb extends BxDolModuleDb
 			`tap`.`trial` AS `trial`,
 			`tap`.`order` AS `order`";
 
+        $sWhereClause = $sJoinClause = '';
+
         if(!isset($aParams['order']) || empty($aParams['order']))
-           $sOrderClause = "ORDER BY `tap`.`Order` ASC";
+            $sOrderClause = "ORDER BY `tap`.`Order` ASC";
 
         switch($aParams['type']) {
             case 'by_id':

--- a/modules/boonex/acl/classes/BxAclDb.php
+++ b/modules/boonex/acl/classes/BxAclDb.php
@@ -40,7 +40,7 @@ class BxAclDb extends BxDolModuleDb
         $sWhereClause = '';
 
         if(!isset($aParams['order']) || empty($aParams['order']))
-           $sOrderClause = "ORDER BY `tal`.`Order` ASC";
+            $sOrderClause = "ORDER BY `tal`.`Order` ASC";
 
         switch($aParams['type']) {
         	case 'by_id':

--- a/studio/classes/BxDolStudioOAuthOAuth2.php
+++ b/studio/classes/BxDolStudioOAuthOAuth2.php
@@ -72,8 +72,6 @@ class BxDolStudioOAuthOAuth2 extends BxDolStudioOAuth implements iBxDolSingleton
 
     protected function getRequestToken()
     {
-        
-
     	$sUrl = bx_append_url_params($this->sApiUrl . 'auth', array(
 			'response_type' => 'code',
 			'client_id' => $this->sKey,


### PR DESCRIPTION
This PR fixed the following issues:

* Remove useless return statement at [the end of a method](https://github.com/unaio/una/compare/master...pH-7:master#diff-e0476173d5259b89d0912f17f2b6d717L233).
* Remove unused variables that were immediately overridden.
* `$sWhereClause` and `$sJoinClause` variables were immediately using assignment operator `.=` but there weren't  created before.
* Remove some extra new lines found.