### PR TITLE
freegeoip.net isn't available anymore. Use freegeoip.app instead

### DIFF
--- a/modules/boonex/mapshow/classes/BxMapShowModule.php
+++ b/modules/boonex/mapshow/classes/BxMapShowModule.php
@@ -8,7 +8,7 @@
  *
  * @{
  */
-define('BX_MAP_SHOW_IP_2_LOCATION_URL', 'http://freegeoip.net/json/');
+define('BX_MAP_SHOW_IP_2_LOCATION_URL', 'https://freegeoip.app/json/');
 
 class BxMapShowModule extends BxDolModule
 {


### PR DESCRIPTION
FreeGeoIP.net shut down https://freegeoip.net/shutdown
I found freegeoip.app which gives exactly the same results as freegeoip.net

FYI, you also have https://freegeoip.live/ and other alternatives, but for the moment, freegeoip.app was very responsive to my tests.

Hope it helps!